### PR TITLE
Pipe stderr as well

### DIFF
--- a/pass.py
+++ b/pass.py
@@ -16,7 +16,7 @@ class Keyring(KeyringBackend):
 
     def get_password(self, service, username):
         proc = Popen(['pass', 'show', '/'.join([service,username])],
-            stdin=None, stdout=PIPE)
+            stdin=None, stdout=PIPE, stderr=PIPE)
         password, _ = proc.communicate()
         proc.wait()
         if(proc.returncode == 0):


### PR DESCRIPTION
Before:

> > > import keyring
> > > print keyring.get_password('aldskfj', 'slkdjf') Error: aldskfj/slkdjf is
> > > not in the password store. None
> > > 
> > > import keyring
> > > print keyring.get_password('aldskfj', 'slkdjf') None
