### PR TITLE
Install pass.py under site-packages instead of /usr/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,9 @@ Installation
 default-keyring=pass.Keyring
 keyring-path=/path/to/your/pass_python_keyring
 ```
-
+- Alternatively, install it with `python setup.py install`, and put the
+following in your *python_keyring/keyringrc.cfg* config:
+```
+[backend]
+default-keyring=pass.Keyring
+```

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Andrew Karpow',
     author_email='andy@ndyk.de',
     keywords=['pass', 'password', 'keyring'],
-    scripts=['pass.py'],
+    py_modules=['pass.py'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Since it is not a binary but a python lib, it's better to install it under 
site-packages. That way, people that install the package through setup.py need 
to specify only the following in the python-keyring/keyringrc.cfg file:

```
[backend]
default-keyring = pass.Keyring
```
