### PR TITLE
typo in py_modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Andrew Karpow',
     author_email='andy@ndyk.de',
     keywords=['pass', 'password', 'keyring'],
-    py_modules=['pass.py'],
+    py_modules=['pass'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
py_modules requires module name, while script requires full file name.
sorry about that
